### PR TITLE
Minor update for PHP7 compatibility

### DIFF
--- a/rocket_sled.class.php
+++ b/rocket_sled.class.php
@@ -174,7 +174,7 @@
         */
         private static function directoryList($dir)
         {
-           $path = '';
+           $path = array();
            $stack[] = $dir;
            
            while ($stack)


### PR DESCRIPTION
Declaring $path variable as an array instead of on an empty string so that PHP7 doesn't throw an error when it's used in array context.